### PR TITLE
Add full page layouts for breakfast site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^14.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@vitejs/plugin-react": "^4.5.1",
         "babel-jest": "^29.7.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
@@ -1462,6 +1463,38 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
@@ -2702,6 +2735,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
+      "integrity": "sha512-e9MeMtVWo186sgvFFJOPGy7/d2j2mZhLJIdVW0C/xDluuOvymEATqz6zKsP0ZmXGzQtqlyjz5sC1sYQUoJG98w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.41.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
@@ -3323,6 +3363,27 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz",
+      "integrity": "sha512-uPZBqSI0YD4lpkIru6M35sIfylLGTyhGHvDZbNLuMA73lMlwJKz5xweH7FajfcCAc2HnINciejA9qTz0dr0M7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.10",
+        "@babel/plugin-transform-react-jsx-self": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-source": "^7.25.9",
+        "@rolldown/pluginutils": "1.0.0-beta.9",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -7238,6 +7299,16 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-router": {
       "version": "6.30.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@vitejs/plugin-react": "^4.5.1",
     "babel-jest": "^29.7.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,26 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
 import Home from "./pages/Home";
-// ... other imports
+import Menu from "./pages/Menu";
+import Gallery from "./pages/Gallery";
+import About from "./pages/About";
+import Reservations from "./pages/Reservations";
+import TransitionWrapper from "./components/TransitionWrapper";
 
 function App() {
   return (
     <Router>
       <Navbar />
       <Routes>
-        <Route path="/" element={<Home />} />
-        {/* Add other routes here */}
+        <Route path="/" element={<TransitionWrapper><Home /></TransitionWrapper>} />
+        <Route path="/menu" element={<TransitionWrapper><Menu /></TransitionWrapper>} />
+        <Route path="/gallery" element={<TransitionWrapper><Gallery /></TransitionWrapper>} />
+        <Route path="/about" element={<TransitionWrapper><About /></TransitionWrapper>} />
+        <Route path="/reservations" element={<TransitionWrapper><Reservations /></TransitionWrapper>} />
       </Routes>
+      <Footer />
     </Router>
   );
 }

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,11 +1,28 @@
 import React from "react";
+import TransitionWrapper from "../components/TransitionWrapper";
 
-const About = () => {
-  return (
-    <div>
-      <h1>About Page</h1>
-    </div>
-  );
-};
+const About = () => (
+  <TransitionWrapper>
+    <main>
+      <h1>About Us</h1>
+      <p>
+        BreakfastCo began as a family-owned diner in 2010 with a simple mission:
+        serve fresh, comforting breakfasts that make every morning brighter.
+        Over the years we've grown, but our passion for great food and warm
+        service remains at the heart of everything we do.
+      </p>
+      <p>
+        Our team carefully sources local ingredients and bakes from scratch
+        every day. We believe in community, quality, and starting the day with a
+        smile.
+      </p>
+      <img
+        src="https://images.unsplash.com/photo-1520206187778-024f22d0eda3?auto=format&fit=crop&w=1200&q=80"
+        alt="Our cheerful BreakfastCo team"
+        style={{ width: "100%", borderRadius: "8px", marginTop: "1rem" }}
+      />
+    </main>
+  </TransitionWrapper>
+);
 
 export default About;

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,11 +1,44 @@
 import React from "react";
+import TransitionWrapper from "../components/TransitionWrapper";
 
-const Gallery = () => {
-  return (
-    <div>
-      <h1>Gallery Page</h1>
-    </div>
-  );
-};
+const images = [
+  {
+    src: "https://images.unsplash.com/photo-1490645935967-10de6ba17061?auto=format&fit=crop&w=800&q=80",
+    alt: "Stack of pancakes with berries",
+  },
+  {
+    src: "https://images.unsplash.com/photo-1551024601-bec78aea704b?auto=format&fit=crop&w=800&q=80",
+    alt: "Bright cafe interior with wooden tables",
+  },
+  {
+    src: "https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=800&q=80",
+    alt: "Friends enjoying breakfast together",
+  },
+];
+
+const Gallery = () => (
+  <TransitionWrapper>
+    <main>
+      <h1>Gallery</h1>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+          gap: "1rem",
+          marginTop: "1rem",
+        }}
+      >
+        {images.map((img, idx) => (
+          <img
+            key={idx}
+            src={img.src}
+            alt={img.alt}
+            style={{ width: "100%", borderRadius: "8px" }}
+          />
+        ))}
+      </div>
+    </main>
+  </TransitionWrapper>
+);
 
 export default Gallery;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,10 +1,57 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import menu from "../data/menu.json";
+import TransitionWrapper from "../components/TransitionWrapper";
 
 const Home = () => {
+  const featured = menu.items.slice(0, 3);
+
   return (
-    <div>
-      <h1>Home Page</h1>
-    </div>
+    <TransitionWrapper>
+      <main>
+        <section style={{ textAlign: "center" }}>
+          <img
+            src="https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=1200&q=80"
+            alt="Breakfast spread with pancakes and coffee"
+            style={{ width: "100%", borderRadius: "8px" }}
+          />
+          <h1>Welcome to BreakfastCo</h1>
+          <p>Start your day with our hearty and delicious breakfasts.</p>
+          <Link to="/reservations">
+            <button style={{ marginTop: "1rem" }}>Reserve a Table</button>
+          </Link>
+        </section>
+        <section style={{ marginTop: "2rem" }}>
+          <h2 style={{ color: "var(--color-callout)" }}>Featured Items</h2>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+              gap: "1rem",
+              marginTop: "1rem",
+            }}
+          >
+            {featured.map((item) => (
+              <article
+                key={item.title}
+                style={{
+                  border: "1px solid var(--color-primary)",
+                  borderRadius: "8px",
+                  padding: "1rem",
+                  background: "white",
+                }}
+              >
+                <h3 style={{ color: "var(--color-primary)", margin: "0 0 0.5rem" }}>
+                  {item.title}
+                </h3>
+                <p style={{ margin: 0 }}>{item.description}</p>
+                <p style={{ fontWeight: "bold", marginTop: "0.5rem" }}>{item.price}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+    </TransitionWrapper>
   );
 };
 

--- a/src/pages/Menu.jsx
+++ b/src/pages/Menu.jsx
@@ -1,10 +1,44 @@
 import React from "react";
+import menu from "../data/menu.json";
+import MenuCard from "../components/MenuCard";
+import TransitionWrapper from "../components/TransitionWrapper";
+
+const groupByCategory = (items) => {
+  const grouped = {};
+  items.forEach((item) => {
+    const cat = item.category || "Other";
+    if (!grouped[cat]) grouped[cat] = [];
+    grouped[cat].push(item);
+  });
+  return grouped;
+};
 
 const Menu = () => {
+  const categories = groupByCategory(menu.items);
+
   return (
-    <div>
-      <h1>Menu Page</h1>
-    </div>
+    <TransitionWrapper>
+      <main>
+        <h1>Our Menu</h1>
+        {Object.keys(categories).map((cat) => (
+          <section key={cat} style={{ marginTop: "1.5rem" }}>
+            <h2 style={{ color: "var(--color-callout)" }}>{cat}</h2>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                gap: "1rem",
+                marginTop: "0.5rem",
+              }}
+            >
+              {categories[cat].map((item) => (
+                <MenuCard key={item.title} item={item} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </main>
+    </TransitionWrapper>
   );
 };
 

--- a/src/pages/Reservations.jsx
+++ b/src/pages/Reservations.jsx
@@ -1,10 +1,41 @@
 import React from "react";
+import TransitionWrapper from "../components/TransitionWrapper";
 
 const Reservations = () => (
-  <div>
-    <h2 style={{ color: "var(--color-callout)" }}>Reservations</h2>
-    <p>Please call us to reserve a table.</p>
-  </div>
+  <TransitionWrapper>
+    <main>
+      <h1>Reserve a Table</h1>
+      <p>
+        Call us at <a href="tel:+123456789">(123) 456-789</a> between 7am and
+        2pm, or send us a request using the form below.
+      </p>
+      <form
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5rem",
+          maxWidth: "400px",
+          margin: "1rem auto",
+        }}
+      >
+        <label>
+          Name
+          <input type="text" name="name" required style={{ width: "100%", padding: "0.5rem" }} />
+        </label>
+        <label>
+          Date
+          <input type="date" name="date" required style={{ width: "100%", padding: "0.5rem" }} />
+        </label>
+        <label>
+          Time
+          <input type="time" name="time" required style={{ width: "100%", padding: "0.5rem" }} />
+        </label>
+        <button type="submit" style={{ marginTop: "0.5rem" }}>
+          Submit
+        </button>
+      </form>
+    </main>
+  </TransitionWrapper>
 );
 
 export default Reservations;

--- a/src/style.css
+++ b/src/style.css
@@ -103,3 +103,22 @@ button:focus-visible {
     background-color: var(--color-highlight);
   }
 }
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+form input {
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+}

--- a/src/tests/pages/Gallery.test.jsx
+++ b/src/tests/pages/Gallery.test.jsx
@@ -1,0 +1,3 @@
+test('placeholder gallery', () => {
+  expect(true).toBe(true);
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- build navigation and footer across pages
- add Home page hero section with featured menu items
- implement Menu page with grouped dishes
- create Gallery page with responsive images
- write About and Reservations pages with themed content
- style forms and layout
- add placeholder test for Gallery
- add Vite React plugin to fix React runtime

## Testing
- `npm install`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68422d710130832ca3b202cbbbef1d0a